### PR TITLE
Enable BTC data merge and compute signal accuracy

### DIFF
--- a/boltzmann.py
+++ b/boltzmann.py
@@ -9,7 +9,10 @@ import matplotlib.pyplot as plt
 # 2. 비트코인 데이터 다운로드 (최근 90일)
 end_date = datetime.today()
 start_date = end_date - timedelta(days=90)
+# 최근 90일 간 비트코인 가격 데이터를 다운로드한다.
+# yfinance 최신 버전에서는 컬럼이 MultiIndex 형태이므로 첫 번째 레벨만 사용한다.
 btc = yf.download('BTC-USD', start=start_date, end=end_date, interval='1d')
+btc = btc.droplevel(1, axis=1)
 btc.dropna(inplace=True)
 
 # 3. 맥스웰-볼츠만 분포 함수 정의
@@ -42,6 +45,14 @@ btc['Signal'] = 0
 btc.loc[btc['Beta_Change'] < 0, 'Signal'] = 1   # 매수 신호 (시장 온도 상승)
 btc.loc[btc['Beta_Change'] > 0, 'Signal'] = -1  # 매도 신호 (시장 냉각)
 
+# 예측 신호의 정확도 측정: 다음 날 종가 변동 방향과 비교
+btc['Next_Close_Change'] = btc['Close'].diff().shift(-1)
+btc['Actual'] = 0
+btc.loc[btc['Next_Close_Change'] > 0, 'Actual'] = 1
+btc.loc[btc['Next_Close_Change'] < 0, 'Actual'] = -1
+accuracy = (btc['Signal'] == btc['Actual']).mean()
+print(f'Signal accuracy: {accuracy:.2%}')
+
 # 7. 결과 시각화
 plt.figure(figsize=(14, 6))
 plt.plot(btc.index, btc['Close'], label='BTC Close Price', color='black')
@@ -59,7 +70,7 @@ plt.ylabel('Price / Beta')
 plt.legend()
 plt.grid(True)
 plt.tight_layout()
-plt.show()
+plt.savefig('btc_beta_plot.png')
 
 # 8. 마지막 30일 데이터 출력
 print(btc.tail(30)[['Close', 'Beta', 'Beta_Change', 'Signal']])


### PR DESCRIPTION
## Summary
- handle yfinance multiindex columns when merging
- save plot instead of showing it interactively
- calculate simple accuracy of buy/sell signals vs next-day close movement

## Testing
- `python3 boltzmann.py > run.log && tail -n 20 run.log`

------
https://chatgpt.com/codex/tasks/task_e_688898fb98288325b600bd9db703553a